### PR TITLE
Include .yaml in .editorconfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
We use this extension for our OpenAPI specification and it seems to
a popular extension for YAML files anyway.