### PR TITLE
Set required environment variables for unit tests

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -36,6 +36,8 @@ action "Specification tests" {
     APP_DEBUG = "true"
     # In non-production environments we can recreate the database before testing
     APP_ENV="testing"
+    # Do not contact the OAuth endpoint during testing.
+    ADGANGSPLATFORMEN_DRIVER="testing"
     # Use SQLite for testing. Use a file in a directory we know we can write to
     DB_CONNECTION = "sqlite"
     DB_DATABASE = "/tmp/db.sqlite"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_DEBUG" value="false"/>
+        <env name="ADGANGSPLATFORMEN_DRIVER" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
     </php>

--- a/tests/contexts/MaterialListContext.php
+++ b/tests/contexts/MaterialListContext.php
@@ -58,6 +58,7 @@ class MaterialListContext implements Context, SnippetAcceptingContext
         // Boot the app.
 
         putenv('APP_ENV=testing');
+        putenv('ADGANGSPLATFORMEN_DRIVER=testing');
 
         // Use in-memory db for speed.
         putenv('DB_CONNECTION=sqlite');


### PR DESCRIPTION
Currently the `ExceptionHandlerTest` will fail if you have a `.env` file
locally with `ADGANGSPLATFORMEN_DRIVER=production`. That does not seem
right.

Set the environment variable to the required value to get the tests
to work regardless.

Note that this change does not fix the problem entirely. Dredd tests will still fail.
I tried setting `ADGANGSPLATFORMEN_DRIVER=testing` in the `.env` file for the action
and in the `env` key for the action in `main.workflow` but it does not seem to make any difference. Help?!