### PR TITLE
Quote application name in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # The application name, used by Lumen.
-APP_NAME=Material list
+APP_NAME="Material list"
 
 # Application key. The output of `openssl rand -base64 24` is a good choice.
 APP_KEY=


### PR DESCRIPTION
Without this you get an error if you copy .env.example to .env.

“The environment file is invalid! Failed to parse dotenv file due to
unexpected whitespace. Failed at [Material list].”