### PR TITLE
Only log errors when running Dredd

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -30,7 +30,7 @@ action "Behaviour Codecov" {
 action "Specification tests" {
   needs = ["Composer install"]
   uses = "./.github/actions/spec-test"
-  runs = "dredd"
+  runs = "dredd --loglevel=error"
   env = {
     # Ensure that we get as much information as possible if tests fail.
     APP_DEBUG = "true"


### PR DESCRIPTION
Dredd currently produces [a good deal of warnings](https://github.com/reload/material-list/runs/191183365) when parsing our
OpenAPI specification. This may be because their support for OpenAPI
3.0 is still maturing.

Reduce the log level to error to remove these warnings from the
default output. The README contains information about how to increase
the log level for debugging purposes.