### PR TITLE
Automatic provision of gcp project and gke cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .env
 /coverage
+.terraform

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,24 @@
+# Material-list hosting infrastructure
+Sample google cloud-based hosting setup.
+
+
+## Requirements
+Material-list requires a host capable of hosting a php7 project, and a backend mysql 5.7+ compatible database.
+
+The rest of this document describes how to setup a complete hosting-environment based on Google Cloud Platform.
+
+Be aware this configuration is "live", ie. if you want to do your own hosting in a fork, you will need to change configuration of eg. the enabled environments and the terraform state storage.
+
+## Provisioning via Google Cloud Platform.
+The Google cloud project is provisioned via Terraform.
+
+You provision a project by applying the terraform configuration in the provisioning/terraform directory. You will need to modify backend.tf to point at a remote backend-store of your choosing, and terraform.tfvars to suit your project.
+
+After the project is created, use provisioning/cluster-setup to perform the last configuration of the Kubernetes cluster prior to doing any deployments.
+
+## Creating environments
+TODO
+
+## Building and deploying
+TODO
+

--- a/infrastructure/provisioning/cluster-setup/01-setup-ingress-controller.sh
+++ b/infrastructure/provisioning/cluster-setup/01-setup-ingress-controller.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${SCRIPT_DIR}"
+
+if [[ $# -lt 1 ]] ; then
+    echo "Syntax: $0 <ingress ip>"
+    exit 1
+fi
+
+INGRESS_IP=$1
+
+echo " > Project ID: ${GCP_PROJECT_ID} ..."
+
+echo " > Installing Nginx Ingress Controller in cluster via Helm ..."
+# controller.publishService.enabled=true will set the endpoint records on the
+# ingress objects to those on the GCLB.
+helm upgrade \
+    --install \
+    --set rbac.create=true \
+    --set controller.kind=DaemonSet \
+    --set controller.service.loadBalancerIP="${INGRESS_IP}" \
+    --set controller.service.externalTrafficPolicy="Local" \
+    --set controller.publishService.enabled=true \
+    nginx-ingress \
+    stable/nginx-ingress
+
+# Apply custom config to the controller.
+kubectl -n default apply -f ./nginx-ingress/configmap.yaml
+
+echo " > Done."
+

--- a/infrastructure/provisioning/cluster-setup/02-install-cert-manager.sh
+++ b/infrastructure/provisioning/cluster-setup/02-install-cert-manager.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+ 
+# See https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html#installing-with-helm
+# Install the CustomResourceDefinition resources separately
+kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.9/deploy/manifests/00-crds.yaml
+
+# Create the namespace for cert-manager
+kubectl create namespace cert-manager
+
+# Label the cert-manager namespace to disable resource validation
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+
+# Add the Jetstack Helm repository
+helm repo add jetstack https://charts.jetstack.io
+
+# Update your local Helm chart repository cache
+helm repo update
+
+# Install the cert-manager Helm chart
+helm install \
+  --name cert-manager \
+  --namespace cert-manager \
+  --version v0.9.1 \
+  jetstack/cert-manager
+
+# Wait for cert-manage pods to come online before proceeding.
+echo " > Waiting for clusterissuers resource to be available in cluster ..."
+sleep 20
+
+# Install the ClusterIssuer for Let's Encrypt (prod).
+kubectl apply -f ./certmanager/clusterissuer.yaml

--- a/infrastructure/provisioning/cluster-setup/README.md
+++ b/infrastructure/provisioning/cluster-setup/README.md
@@ -1,0 +1,22 @@
+# Kubernetes final configuration
+The cluster setup assumes you've either installed helm in the cluster, or are using Tillerless (https://github.com/rimusz/helm-tiller). 
+
+Also you're local kubectl must be configured with a valid context for the project.
+
+For google cloud this means eg.
+```shell
+# Reference terraform.tfvars and variables.tf for the project and region.
+gcloud --project <my project> --region <my region> container clusters get-credentials primary-cluster 
+```
+
+## Provisioning
+```shell
+
+# Provision an external IP for the kubernetes cluster, then setup the ingress controller
+./01-setup-ingress-controller.sh <external ip>
+
+# Then add certmanager to the cluster for certificate provisioning.
+# Make sure to update certmanager/clusterissuer.yaml with your client email
+./02-install-cert-manager.sh
+
+```

--- a/infrastructure/provisioning/cluster-setup/certmanager/clusterissuer.yaml
+++ b/infrastructure/provisioning/cluster-setup/certmanager/clusterissuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: security+materiallist@reload.dk
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - selector: {}
+      http01:
+        ingress:
+          class: nginx

--- a/infrastructure/provisioning/cluster-setup/nginx-ingress/configmap.yaml
+++ b/infrastructure/provisioning/cluster-setup/nginx-ingress/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-ingress-controller
+  labels:
+    app: nginx-ingress
+data:
+  enable-underscores-in-headers: "true"
+  log-format-escape-json: "true"
+  # See https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#httprequest and https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/
+  log-format-upstream: '{"httpRequest":{"requestMethod":"$request_method","requestUrl":"$request_uri","requestSize":"$request_length","status":$status,"responseSize":"$upstream_response_length","userAgent":"$http_user_agent","remoteIp":"$the_real_ip","serverIp":"$remote_addr","referer":"$http_referer","latency":"$upstream_response_time"},"remoteUser":"$remote_user","timeLocal":"$time_local","bodyBytesSent":"$body_bytes_sent","requestTime":"$request_time","proxyUpstreamName":"$proxy_upstream_name","upstreamAddr":"$upstream_addr","upstreamStatus":"$upstream_status","reqId":"$req_id"}'

--- a/infrastructure/provisioning/terraform/backend.tf
+++ b/infrastructure/provisioning/terraform/backend.tf
@@ -1,0 +1,7 @@
+
+terraform {
+  backend "gcs" {
+    bucket = "reops-oc-state-110242"
+    prefix = "state/reload-material-list"
+  }
+}

--- a/infrastructure/provisioning/terraform/cloud-sql.tf
+++ b/infrastructure/provisioning/terraform/cloud-sql.tf
@@ -1,0 +1,117 @@
+resource "google_sql_database_instance" "master" {
+  provider = "google-beta"
+
+  name   = "material-list-alpha2"
+  region = "${var.region}"
+
+  database_version = "MYSQL_5_7"
+
+  depends_on = [
+    "google_service_networking_connection.private_vpc_connection"
+  ]
+  settings {
+    # Second-generation instance tiers are based on the machine
+    # type. See argument reference below.
+    tier            = "${var.db_instance_type}"
+    disk_autoresize = true
+    disk_size       = 50
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = "${google_compute_network.private_network.self_link}"
+    }
+
+    backup_configuration {
+      binary_log_enabled = "true"
+      enabled            = "true"
+      start_time         = "03:04"
+    }
+
+    location_preference {
+      zone = "${var.zone_1}"
+    }
+  }
+}
+
+resource "google_sql_database_instance" "replica" {
+  name   = "material-list-beta2"
+  region = "${var.region}"
+
+  database_version     = "MYSQL_5_7"  
+  master_instance_name = "${google_sql_database_instance.master.name}"
+
+  replica_configuration {
+    connect_retry_interval = "30"
+    failover_target        = "true"
+  }
+
+  settings {
+    tier            = "${var.db_instance_type}"
+    disk_autoresize = true
+    disk_size       = 50
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = "${google_compute_network.private_network.self_link}"
+    }
+
+    location_preference {
+      zone = "${var.zone_2}"
+    }
+
+  }
+}
+
+resource "google_sql_database" "ml_prod" {
+  name      = "ml_prod"
+  instance  = "${google_sql_database_instance.master.name}"
+  charset   = "utf8mb4"
+  collation = "utf8mb4_general_ci"
+}
+
+resource "google_sql_user" "ml_prod" {
+  name     = "ml_prod_user"
+  instance = "${google_sql_database_instance.master.name}"
+  password = "oil5aiQuee"
+}
+
+resource "google_sql_database" "ml_test" {
+  name      = "ml_test"
+  instance  = "${google_sql_database_instance.master.name}"
+  charset   = "utf8mb4"
+  collation = "utf8mb4_general_ci"
+}
+
+resource "google_sql_user" "ml_test" {
+  name     = "ml_test_user"
+  instance = "${google_sql_database_instance.master.name}"
+  password = "ahs2faaFee"
+}
+
+
+output "master_private_ip" {
+  value = "${google_sql_database_instance.master.private_ip_address}"
+}
+
+output "master_public_ip" {
+  value       = "${google_sql_database_instance.master.ip_address.0.ip_address}"
+  description = "The IPv4 address assigned for master"
+}
+
+output "test_sql_user_username" {
+  value       = "${google_sql_user.ml_test.name}"
+  description = "Username for the cloud sql test user"
+}
+
+output "test_sql_user_password" {
+  value       = "${google_sql_user.ml_test.password}"
+  description = "Password for the cloud sql test user"
+}
+
+output "prod_sql_user_username" {
+  value       = "${google_sql_user.ml_prod.name}"
+  description = "Username for the cloud sql prod user"
+}
+
+output "prod_sql_user_password" {
+  value       = "${google_sql_user.ml_prod.password}"
+  description = "Password for the cloud sql prod user"
+}

--- a/infrastructure/provisioning/terraform/gke.tf
+++ b/infrastructure/provisioning/terraform/gke.tf
@@ -1,0 +1,104 @@
+resource "google_container_cluster" "primary" {
+  name           = "primary-cluster"
+  location       = "${var.region}"
+  node_locations = ["${var.zone_1}"]
+  provider       = "google-beta"
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network = "${google_compute_network.private_network.self_link}"
+
+  master_auth {
+    username = ""
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  # Enable Stackdriver Kubernetes monitoring and logging
+  logging_service    = "logging.googleapis.com/kubernetes"
+  monitoring_service = "monitoring.googleapis.com/kubernetes"
+  # Allows us to see flow logs for all traffic
+  # between Pods, including traffic between Pods on the same node. See
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility
+  enable_intranode_visibility = true
+
+
+  ip_allocation_policy {
+    # Enable use of alias IPs for pod IPs. This makes the cluster
+    # VPC-native which is a requirement in order to network privately with Cloud
+    # SQL. See https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips
+    use_ip_aliases = true
+  }
+
+  vertical_pod_autoscaling {
+    enabled = true
+  }
+
+  addons_config {
+    # Overrides default addon list and disables the built-in GCE Ingress controller (HttpLoadBalancing addon), since we are
+    # using nginx-ingress. See https://stackoverflow.com/a/54407496/1446678
+    http_load_balancing {
+      disabled = true
+    }
+  }
+
+  maintenance_policy {
+    daily_maintenance_window {
+      start_time = "02:00"
+    }
+  }
+}
+
+resource "google_container_node_pool" "primary_preemptible_nodes" {
+  name     = "${var.pool_preemptible_name}"
+  cluster  = "${google_container_cluster.primary.name}"
+  location = "${var.region}"
+
+  depends_on = [
+    "google_container_cluster.primary"
+  ]
+  node_count = "${var.pool_preemptible_node_count}"
+  provider   = "google-beta"
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    preemptible     = true
+    machine_type    = "${var.pool_preemptible_machine_type}"
+    service_account = "${google_service_account.cluster-node.email}"
+    disk_size_gb    = 50
+
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    # Not stable yet
+    # image_type      = "COS_CONTAINERD"
+    # sandbox_config {
+    #   sandbox_type = "gvisor"
+    # }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/sqlservice.admin"
+    ]
+  }
+}
+
+
+output "cluster-name" {
+  value = "${google_container_cluster.primary.name}"
+}

--- a/infrastructure/provisioning/terraform/network.tf
+++ b/infrastructure/provisioning/terraform/network.tf
@@ -1,0 +1,38 @@
+# Allocate an external ip for the cluster ingress.
+resource "google_compute_address" "ingress_address" {
+  name         = "ingress-address"
+  address_type = "EXTERNAL"
+}
+output "ingress_address" {
+  value = google_compute_address.ingress_address.address
+}
+
+# Setup a private network that can host communication between cloudsql and the 
+# kubernetes cluster.
+# Create the network.
+resource "google_compute_network" "private_network" {
+  provider                = "google-beta"
+  auto_create_subnetworks = "true"
+  name                    = "private-db-network"
+}
+
+# Configure ips.
+resource "google_compute_global_address" "private_ip_address" {
+  provider = "google-beta"
+
+  name          = "private-ip-address"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 20
+  network       = "${google_compute_network.private_network.self_link}"
+}
+
+# Setup a connection the users of the network can access.
+resource "google_service_networking_connection" "private_vpc_connection" {
+  provider = "google-beta"
+
+  network                 = "${google_compute_network.private_network.self_link}"
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = ["${google_compute_global_address.private_ip_address.name}"]
+}
+

--- a/infrastructure/provisioning/terraform/project.tf
+++ b/infrastructure/provisioning/terraform/project.tf
@@ -1,0 +1,39 @@
+# Configure a project with a deprivileged serviceaccount.
+module "project-factory" {
+  source                  = "terraform-google-modules/project-factory/google"
+  version                 = "~> 3.2"
+  project_id              = "${var.project_id}"
+  name                    = "${var.project_name}"
+  org_id                  = "${var.organization_id}"
+  billing_account         = "${var.billing_account}"
+  default_service_account = "depriviledge"
+  lien                    = "true"
+  credentials_path        = "/tmp/credentials.json"
+  activate_apis = [
+    "cloudbuild.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "container.googleapis.com",
+    "compute.googleapis.com",
+    "logging.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "sql-component.googleapis.com",
+    "sqladmin.googleapis.com"
+  ]
+}
+
+# Grant reload developers editor access to the project, k8s and storage.
+resource "google_project_iam_member" "grant-developer-editor" {
+  project = module.project-factory.project_id
+  role    = "roles/editor"
+  member  = "group:developers@reload.dk"
+}
+resource "google_project_iam_member" "grant-developer-gke" {
+  project = module.project-factory.project_id
+  role    = "roles/container.admin"
+  member  = "group:developers@reload.dk"
+}
+resource "google_project_iam_member" "grant-developer-storage" {
+  project = module.project-factory.project_id
+  role    = "roles/storage.admin"
+  member  = "group:developers@reload.dk"
+}

--- a/infrastructure/provisioning/terraform/provider.tf
+++ b/infrastructure/provisioning/terraform/provider.tf
@@ -1,0 +1,13 @@
+# Setup access to google cloud.
+# Credentials are assumed to be available via a 
+provider "google" {
+  version = "~> 2.12"
+  region  = "${var.region}"
+  project = "${var.project_id}"
+}
+
+provider "google-beta" {
+  version = "~> 2.12"
+  region  = "${var.region}"
+  project = "${var.project_id}"
+}

--- a/infrastructure/provisioning/terraform/service-accounts.tf
+++ b/infrastructure/provisioning/terraform/service-accounts.tf
@@ -1,0 +1,24 @@
+# Create a service-account for the cluster.
+resource "google_service_account" "cluster-node" {
+  account_id   = "${var.cluster_node_service_account_id}"
+  display_name = "GKE Cluster Node Service Account"
+}
+
+# Grant the cluster service-account access to write logs, read and write metrics,
+# and pull images from google-storage.
+resource "google_project_iam_member" "cluster-node-logwriter" {
+  role   = "roles/logging.logWriter"
+  member = "serviceAccount:${google_service_account.cluster-node.email}"
+}
+resource "google_project_iam_member" "cluster-node-metric-writer" {
+  role   = "roles/monitoring.metricWriter"
+  member = "serviceAccount:${google_service_account.cluster-node.email}"
+}
+resource "google_project_iam_member" "cluster-node-monitoring-viewer" {
+  role   = "roles/monitoring.viewer"
+  member = "serviceAccount:${google_service_account.cluster-node.email}"
+}
+resource "google_project_iam_member" "cluster-node-storage-viewer" {
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.cluster-node.email}"
+}

--- a/infrastructure/provisioning/terraform/terraform.tfvars
+++ b/infrastructure/provisioning/terraform/terraform.tfvars
@@ -1,0 +1,5 @@
+billing_account  = "01520D-3B72DC-909687"
+organization_id  = "1083039425201"
+project_name     = "DBC Material List"
+project_id       = "reload-material-list-3"
+db_instance_type = "db-n1-standard-1"

--- a/infrastructure/provisioning/terraform/variables.tf
+++ b/infrastructure/provisioning/terraform/variables.tf
@@ -1,0 +1,50 @@
+variable "project_name" {
+  description = "Project name"
+}
+
+variable "project_id" {
+  description = "unique project id"
+}
+
+variable "billing_account" {
+  description = "ID for the billing-account associated with the project"
+}
+variable "organization_id" {
+  description = "ID of the organization that hosts the project"
+}
+variable "region" {
+  description = "Region the project-resources should be created in"
+  default     = "europe-west1"  
+}
+variable "db_instance_type" {
+  description = "The vm instance type used for hosting cloudsql"
+}
+variable "zone_1" {
+  description = "The primary zone used to host the cluster nodes and primary cloudsql pr. default"
+  default     = "europe-west1-b"
+}
+variable "zone_2" {
+  description = "The secondary zone that will hold the cloudsql read replica."
+  default     = "europe-west1-c"
+}
+
+variable "cluster_node_service_account_id" {
+  description = "The Id of the service-account the gke cluster nodes will run as"
+  default     = "gke-cluster-node"
+}
+
+variable "pool_preemptible_name" {
+  description = "Name of the preemptible node pool"
+  default     = "preempt-2cpu-7500"
+}
+
+variable "pool_preemptible_node_count" {
+  description = "Number of nodes in the preemptible node-pool"
+  type        = number
+  default     = 2
+
+}
+variable "pool_preemptible_machine_type" {
+  description = "The machine-type used for the node-pool"
+  default     = "n1-standard-2"
+}


### PR DESCRIPTION
This pull-request implements automated provisioning of the material-list hosting environment.

The provisioning should create
* A google cloud project.
* A kubernetes cluster with a few preemptible nodes.
* The various serviceaccounts nessecary and their role-mappings
* Configure the cluster for public ingress and auto-provisioning of https certifcates.