### PR TITLE
Bump PHP to 7.3

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -10,13 +10,13 @@ action "Composer install" {
 
 action "Behaviour tests" {
   needs = ["Composer install"]
-  uses = "docker://php:7.2-alpine"
+  uses = "docker://php:7.3-alpine"
   runs = "phpdbg -qrr vendor/bin/behat --strict"
 }
 
 action "Behaviour test coverage" {
   needs = ["Behaviour tests"]
-  uses = "docker://php:7.2-alpine"
+  uses = "docker://php:7.3-alpine"
   runs = "phpdbg -qrr vendor/bin/phpcov merge --clover=coverage/behat.xml coverage/default.cov"
 }
 
@@ -46,7 +46,7 @@ action "Specification tests" {
 
 action "Unit tests" {
   needs = ["Composer install"]
-  uses = "docker://php:7.2-alpine"
+  uses = "docker://php:7.3-alpine"
   runs = "phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage/unit.xml"
 }
 
@@ -59,13 +59,13 @@ action "Unit Codecov" {
 
 action "Check codestyle" {
   needs = ["Composer install"]
-  uses = "docker://php:7.2-alpine"
+  uses = "docker://php:7.3-alpine"
   runs = "vendor/bin/phpcs"
 }
 
 action "Static code analysis" {
   needs = ["Composer install"]
-  uses = "docker://php:7.2-alpine"
+  uses = "docker://php:7.3-alpine"
   runs = "vendor/bin/phpstan analyse ."
 }
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -4,7 +4,7 @@ This directory contains configuration, scripts and tools for hosting Material Li
 ## Requirements
 Material-list requires a host with the following software:
 - Nginx 1.17
-- PHP 7.2
+- PHP 7.3
 - Mysql 5.7+ compatible database
 Individual components can be swapped for relevant alternatives. Apache can be used instead of Nginx. Any [database supported by Laravel](https://laravel.com/docs/5.8/database) such as PostgresSQL, SQLite and SQL Server can replace MariaDB.
 

--- a/infrastructure/docker/php-fpm/Dockerfile
+++ b/infrastructure/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm-alpine
+FROM php:7.3-fpm-alpine
 
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
Active support for PHP 7.2 will end in two months. We might as well
get to the newer version up.