### PR TITLE
Simplify GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,56 +3,49 @@ name: Build, test, and deploy
 jobs:
   check_codestyle:
     name: Codestyle
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Check codestyle
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: vendor/bin/phpcs
   static_code_analysis:
     name: Static Code Analysis
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Static code analysis
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: vendor/bin/phpstan
         args: analyse .
   unit_tests:
     name: Unit tests
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Unit tests
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: phpdbg
         args: -qrr ./vendor/bin/phpunit --coverage-clover=coverage/unit.xml
     - name: Unit Codecov
-      if: '!github.event.deleted'
       uses: ./.github/actions/codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -60,29 +53,25 @@ jobs:
         args: -F Unit -f coverage/unit.xml
   behaviour_tests:
     name: Behaviour tests
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Behaviour tests
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: phpdbg
         args: -qrr vendor/bin/behat --strict
     - name: Behaviour test coverage
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: phpdbg
         args: -qrr vendor/bin/phpcov merge --clover=coverage/behat.xml coverage/default.cov
     - name: Behaviour Codecov
-      if: '!github.event.deleted'
       uses: ./.github/actions/codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -90,28 +79,25 @@ jobs:
         args: -F Behaviour -f coverage/behat.xml
   specification_lint:
     name: Specification linting
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Lint specification
-      if: '!github.event.deleted'
       uses: docker://wework/speccy
       with:
         args: lint material-list.yaml
   specification_tests:
     name: Specification tests
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Specification tests
-      if: '!github.event.deleted'
       uses: ./.github/actions/spec-test
       env:
         ADGANGSPLATFORMEN_DRIVER: testing
@@ -124,18 +110,18 @@ jobs:
         args: --loglevel=error
   test_build_release_image:
     name: Test build of a release image
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Build release Docker image
-      if: '!github.event.deleted'
       uses: actions/docker/cli@master
       with:
         args: build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
           -f infrastructure/docker/release/Dockerfile .
   deploy:
     name: Deploy
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !github.event.deleted
     needs:
     - check_codestyle
     - static_code_analysis
@@ -147,31 +133,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !github.event.deleted
     - name: Build release Docker image
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !github.event.deleted
       uses: actions/docker/cli@master
       with:
         args: build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
           -f infrastructure/docker/release/Dockerfile .
     - name: Set Credential Helper for Docker
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !github.event.deleted
       uses: actions/gcloud/cli@master
       with:
         args: auth configure-docker --quiet
     - name: Setup Google Cloud
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !github.event.deleted
       uses: actions/gcloud/auth@master
       env:
         GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
     - name: Push image to GCR
-      if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && !github.event.deleted
       uses: actions/gcloud/cli@master
       with:
         entrypoint: sh
         args: -c "docker push eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
     - name: Deploy to Test
-      if: github.ref == 'refs/heads/develop' && !github.event.deleted
       uses: ./.github/actions/deployer
       env:
         GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
@@ -183,7 +163,6 @@ jobs:
       with:
         args: test
     - name: Deploy to Prod
-      if: github.ref == 'refs/heads/master' && !github.event.deleted
       uses: ./.github/actions/deployer
       env:
         GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}


### PR DESCRIPTION
Simplify GitHub Actions by moving if conditions from each step and into the job instead.

[This is now supported](https://github.community/t5/GitHub-API-Development-and/jobs-lt-job-id-gt-if-not-working/m-p/32721#M3094).