### PR TITLE
Replace Docker action with runnable command

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -121,9 +121,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build release Docker image
-      uses: actions/docker/cli@master
-      with:
-        args: build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
+      run: docker build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
           -f infrastructure/docker/release/Dockerfile .
   deploy:
     name: Deploy
@@ -140,9 +138,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build release Docker image
-      uses: actions/docker/cli@master
-      with:
-        args: build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
+      run: docker build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
           -f infrastructure/docker/release/Dockerfile .
     - name: Set Credential Helper for Docker
       uses: actions/gcloud/cli@master


### PR DESCRIPTION
[The action has been deprecated and is no longer available](https://github.community/t5/GitHub-Actions/Docker-action-deprecated-and-archived/td-p/33219). Replace it with the Docker installation already available.