### PR TITLE
Ddblm 71 local id handling

### DIFF
--- a/app/Http/Controllers/ListController.php
+++ b/app/Http/Controllers/ListController.php
@@ -3,11 +3,13 @@
 namespace App\Http\Controllers;
 
 use Carbon\Carbon;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
 use Laravel\Lumen\Routing\Controller;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class ListController extends Controller
 {
@@ -27,7 +29,11 @@ class ListController extends Controller
             // comma separated value and just split it up here. Looks nicer in
             // the URL.
             $ids = explode(',', $request->get('material_ids'));
-            $query->whereIn('material', $ids);
+            $query->where(function ($query) use ($ids) {
+                foreach ($ids as $id) {
+                    $this->materialQuery($query, $id, true);
+                }
+            });
         }
 
         $materials = $query->orderBy('changed_at', 'DESC')
@@ -43,9 +49,10 @@ class ListController extends Controller
     public function checkMaterial(Request $request, string $listId, string $materialId)
     {
         $this->checkList($listId);
+        $this->checkMaterialId($materialId);
 
-        $count = DB::table('materials')
-            ->where(['guid' => $request->user()->getId(), 'list' => $listId, 'material' => $materialId])
+        $count = $this->materialQuery(DB::table('materials'), $materialId)
+            ->where(['guid' => $request->user()->getId(), 'list' => $listId])
             ->count();
 
         if ($count > 0) {
@@ -59,18 +66,21 @@ class ListController extends Controller
     {
         $this->checkList($listId);
 
+        $this->materialQuery(DB::table('materials'), $materialId)
+            ->where([
+                'guid' => $request->user()->getId(),
+                'list' => $listId,
+            ])
+            ->delete();
+
         DB::table('materials')
-            ->updateOrInsert(
-                [
-                    'guid' => $request->user()->getId(),
-                    'list' => $listId,
-                    'material' => $materialId,
-                ],
-                [
-                    // We need to format the date ourselves to add microseconds.
-                    'changed_at' => Carbon::now()->format('Y-m-d H:i:s.u'),
-                ]
-            );
+            ->insert([
+                'guid' => $request->user()->getId(),
+                'list' => $listId,
+                'material' => urldecode($materialId),
+                // We need to format the date ourselves to add microseconds.
+                'changed_at' => Carbon::now()->format('Y-m-d H:i:s.u'),
+            ]);
 
         return new Response('', 201);
     }
@@ -79,20 +89,44 @@ class ListController extends Controller
     {
         $this->checkList($listId);
 
-        $count = DB::table('materials')
+        $count = $this->materialQuery(DB::table('materials'), $materialId)
             ->where([
                 'guid' => $request->user()->getId(),
                 'list' => $listId,
-                'material' => $materialId,
-            ])->delete();
+            ])
+            ->delete();
 
         return new Response('', $count > 0 ? 204 : 404);
     }
 
-    protected function checkList($listId)
+    protected function checkList(string $listId): void
     {
         if ($listId != 'default') {
             throw new NotFoundHttpException('No such list');
         }
+    }
+
+    protected function checkMaterialId(string $materialId): array
+    {
+        if (!preg_match('/(\d+)-(\w+):(\d+)/', $materialId, $matches)) {
+            throw new UnprocessableEntityHttpException('Invalid pid: ' . $materialId);
+        }
+        return [$matches[1], $matches[2], $matches[3]];
+    }
+
+    /**
+     * Create a query that deals properly with basis/katalog materials.
+     */
+    protected function materialQuery(Builder $query, string $materialId, $useOr = true): Builder
+    {
+        [$agency, $base, $id] = $this->checkMaterialId(urldecode($materialId));
+
+        $materialWhere = ['material', '=', $agency . '-' . $base . ':' . $id];
+
+        if (\in_array($base, ['katalog', 'basis'])) {
+            $materialWhere = ['material', 'LIKE', '%:' . $id];
+        }
+
+        return $useOr ? $query->orWhere([$materialWhere]) : $query->where([$materialWhere]);
     }
 }

--- a/material-list.yaml
+++ b/material-list.yaml
@@ -1,1 +1,1 @@
-spec/material-list-1.0.0.yaml
+spec/material-list-1.0.1.yaml

--- a/spec/material-list-1.0.1.yaml
+++ b/spec/material-list-1.0.1.yaml
@@ -1,0 +1,179 @@
+openapi: 3.0.0
+info:
+  version: '1.0.0'
+  title: 'Material list'
+  license:
+    name: 'GNU General Public License v3.0'
+    url: 'https://www.gnu.org/licenses/gpl-3.0.html'
+
+servers:
+  - url: https://prod.materiallist.dandigbib.org
+    description: Production server (uses live data)
+  - url: https://test.materiallist.dandigbib.org
+    description: Test server (uses test data)
+
+tags:
+  - name: 'List'
+    description: List handling
+  - name: 'Migrate'
+    description: Data migration
+security:
+  - BearerAuth: []
+paths:
+  /list/{listId}:
+    get:
+      operationId: getList
+      tags:
+        - List
+      description: 'Get list with materials.'
+      parameters:
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/materialIds'
+      responses:
+        200:
+          description: 'The list data is returned.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/List'
+        404:
+          description: 'Unknown list.'
+        422:
+          description: 'Invalid material id.'
+        default:
+          description: 'Unspecified error.'
+
+  /list/{listId}/{materialId}:
+    head:
+      operationId: checkListMaterial
+      tags:
+        - List
+      description: 'Check existence of material on list. To check multiple materials in one request, see the material_ids query parameter on /list/{listId}.'
+      parameters:
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/materialId'
+      responses:
+        200:
+          description: 'The material exists on the list.'
+        404:
+          description: 'The list or material does not exist.'
+        422:
+          description: 'Invalid material id.'
+        default:
+          description: 'Unspecified error.'
+    put:
+      operationId: addListMaterial
+      tags:
+        - List
+      description: 'Add material to the the list.'
+      parameters:
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/materialId'
+      responses:
+        201:
+          description: 'The material was successfully added to the list.'
+        404:
+          description: 'Unknown list.'
+        422:
+          description: 'Invalid material id.'
+        default:
+          description: 'Unspecified error.'
+    delete:
+      operationId: deleteListMaterial
+      tags:
+        - List
+      description: 'Delete material from list.'
+      parameters:
+        - $ref: '#/components/parameters/listId'
+        - $ref: '#/components/parameters/materialId'
+      responses:
+        204:
+          description: 'Successfully removed.'
+        404:
+          description: 'Unknown list or material.'
+        422:
+          description: 'Invalid material id.'
+        default:
+          description: 'Unspecified error.'
+  /migrate/{legacyUserId}:
+    put:
+      operationId: migrateList
+      tags:
+        - Migrate
+      description: 'Migrate list for the legacy user identifier to current user.'
+      parameters:
+        - $ref: '#/components/parameters/legacyUserId'
+      responses:
+        204:
+          description: 'Successfully migrated.'
+        default:
+          description: 'Unspecified error.'
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    listId:
+      name: 'listId'
+      in: 'path'
+      description: 'The identifier of the list to return. Use "default" for the default list.'
+      required: true
+      example: 'default'
+      schema:
+        $ref: '#/components/schemas/ListId'
+    materialId:
+      name: 'materialId'
+      in: 'path'
+      description: 'The identifier of the material.'
+      required: true
+      example: '870970-basis:54871910'
+      schema:
+        $ref: '#/components/schemas/MaterialId'
+    materialIds:
+      name: 'material_ids'
+      in: 'query'
+      description: 'Filter the list reply down to the given material identifiers. This is the recommended way to check for existence of multiple materials on the list.'
+      example:
+        - 870970-basis:54871910
+        - 870970-basis:44791668
+      explode: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/MaterialId'
+    legacyUserId:
+      name: 'legacyUserId'
+      in: 'path'
+      description: 'Legacy user identifier of a migrated list.'
+      required: true
+      example: '29A10F616FE6CA5C6E06EBF507A9FDC5BB89F8EBCF65726BEAC61C646854E83856D3B1D46BE4696EDCFB3C9F57EEBB6941D8654BC1F4B514D6217141AEA1653C'
+      schema:
+        $ref: '#/components/schemas/LegacyUserId'
+
+  schemas:
+    ListId:
+      description: 'List identifier. In the initial version, this can only be "default".'
+      type: string
+    MaterialId:
+      description: 'A material identifier in the form <digits>-<alphanum>:<digits>.'
+      type: string
+      pattern: '^\d+-\w+:\d+$'
+    List:
+      type: object
+      required:
+        - id
+        - materials
+      additionalProperties: false
+      properties:
+        id:
+          $ref: '#/components/schemas/ListId'
+        materials:
+          type: array
+          items:
+            $ref: '#/components/schemas/MaterialId'
+    LegacyUserId:
+      description: 'Legacy user identifier.'
+      type: string
+      example: '29A10F616FE6CA5C6E06EBF507A9FDC5BB89F8EBCF65726BEAC61C646854E83856D3B1D46BE4696EDCFB3C9F57EEBB6941D8654BC1F4B514D6217141AEA1653C'

--- a/tests/contexts/MaterialListContext.php
+++ b/tests/contexts/MaterialListContext.php
@@ -166,6 +166,14 @@ class MaterialListContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Then the system should return validation error
+     */
+    public function theSystemShouldReturnValidationError()
+    {
+        $this->checkStatusCode(422);
+    }
+
+    /**
      * Check that status code is the expected.
      */
     protected function checkStatusCode($expected)

--- a/tests/dredd/hooks.php
+++ b/tests/dredd/hooks.php
@@ -56,3 +56,18 @@ Hooks::before('/list/{listId} > GET > 404', function (&$transaction) use ($pathR
 Hooks::before('/list/{listId}/{materialId} > PUT > 404', function (&$transaction) use ($pathReplace) {
     $pathReplace($transaction, 'default', 'bad-value');
 });
+
+// Change to bad material id.
+Hooks::before('/list/{listId} > GET > 422', function (&$transaction) use ($pathReplace) {
+    $pathReplace($transaction, '870970-basis%3A54871910', 'bad-materialId');
+});
+
+// Change to bad material id.
+Hooks::before('/list/{listId}/{materialId} > PUT > 422', function (&$transaction) use ($pathReplace) {
+    $pathReplace($transaction, '870970-basis%3A54871910', 'bad-materialId');
+});
+
+// Change to bad material id.
+Hooks::before('/list/{listId}/{materialId} > DELETE > 422', function (&$transaction) use ($pathReplace) {
+    $pathReplace($transaction, '870970-basis%3A54871910', 'bad-materialId');
+});

--- a/tests/features/add_to_list.feature
+++ b/tests/features/add_to_list.feature
@@ -28,3 +28,25 @@ Feature: Add to list
     And fetching the list should return:
         | material  |
         | 123-kat:1 |
+
+  Scenario: Adding a material requires a valid pid
+    Given a known user
+    And they have the following items on the list:
+      | material  |
+      | 123-kat:1 |
+    When "banana" is added to the list
+    Then the system should return validation error
+
+  Scenario: Materials in katalog/basis should only be added once, even if it has another agency
+    Given a known user
+    And they have the following items on the list:
+      | material      |
+      | 123-katalog:1 |
+      | 321-basis:2 |
+    When "321-basis:1" is added to the list
+    And "123-katalog:2" is added to the list
+    Then the system should return success
+    And fetching the list should return:
+      | material      |
+      | 123-katalog:2 |
+      | 321-basis:1   |

--- a/tests/features/add_to_list.feature
+++ b/tests/features/add_to_list.feature
@@ -3,28 +3,28 @@ Feature: Add to list
 
   Scenario: Add material to list
     Given a known user that has no items on list
-    When "pid-1" is added to the list
+    When "123-kat:1" is added to the list
     Then the system should return success
-    And "pid-1" should be on the list
+    And "123-kat:1" should be on the list
 
   Scenario: Add material to existing list
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-      | pid-2    |
-      | pid-3    |
-    When "pid-4" is added to the list
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
+    When "123-kat:4" is added to the list
     Then the system should return success
-    And "pid-4" should be on the list
+    And "123-kat:4" should be on the list
 
   Scenario: Materials should only be added once
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-    When "pid-1" is added to the list
+      | material  |
+      | 123-kat:1 |
+    When "123-kat:1" is added to the list
     Then the system should return success
     And fetching the list should return:
-      | material |
-      | pid-1    |
+        | material  |
+        | 123-kat:1 |

--- a/tests/features/delete_from_list.feature
+++ b/tests/features/delete_from_list.feature
@@ -4,13 +4,13 @@ Feature: Deleting materials from list
   Scenario: User should be able to delete material
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-      | pid-2    |
-      | pid-3    |
-    When deleting "pid-2" from the list
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
+    When deleting "123-kat:2" from the list
     Then the system should return success
     And fetching the list should return:
-      | material |
-      | pid-3    |
-      | pid-1    |
+      | material  |
+      | 123-kat:3 |
+      | 123-kat:1 |

--- a/tests/features/delete_from_list.feature
+++ b/tests/features/delete_from_list.feature
@@ -14,3 +14,32 @@ Feature: Deleting materials from list
       | material  |
       | 123-kat:3 |
       | 123-kat:1 |
+
+  Scenario: Deleting a material requires a valid pid
+    Given a known user
+    And they have the following items on the list:
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
+    When deleting "banana" from the list
+    Then the system should return validation error
+    And fetching the list should return:
+      | material  |
+      | 123-kat:3 |
+      | 123-kat:2 |
+      | 123-kat:1 |
+
+  Scenario: User should be able to delete basis/katalog material, even with other agency
+    Given a known user
+    And they have the following items on the list:
+      | material      |
+      | 123-katalog:1 |
+      | 123-katalog:2 |
+      | 321-basis:3 |
+    When deleting "312-basis:2" from the list
+    And deleting "123-katalog:3" from the list
+    Then the system should return success
+    And fetching the list should return:
+        | material      |
+        | 123-katalog:1 |

--- a/tests/features/get_list.feature
+++ b/tests/features/get_list.feature
@@ -15,52 +15,52 @@ Feature: Fetching list
   Scenario: User can fetch their list
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-      | pid-2    |
-      | pid-3    |
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
     When fetching the list
     Then the system should return success
     And the list should contain:
-      | material |
-      | pid-3    |
-      | pid-2    |
-      | pid-1    |
+        | material  |
+        | 123-kat:3 |
+        | 123-kat:2 |
+        | 123-kat:1 |
 
   Scenario: A user can check that a material is on the list
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-      | pid-2    |
-      | pid-3    |
-    When checking if "pid-2" is on the list
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
+    When checking if "123-kat:2" is on the list
     Then the system should return success
 
   Scenario: A user can check that a material is not on the list
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-      | pid-2    |
-      | pid-3    |
-    When checking if "pid-4" is on the list
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
+    When checking if "123-kat:4" is on the list
     Then the system should return not found
 
   Scenario: A user can check that a set of materials is on the list
     Given a known user
     And they have the following items on the list:
-      | material |
-      | pid-1    |
-      | pid-2    |
-      | pid-3    |
-      | pid-4    |
+        | material  |
+        | 123-kat:1 |
+        | 123-kat:2 |
+        | 123-kat:3 |
+        | 123-kat:4 |
     When checking if the list contains:
-      | material |
-      | pid-2    |
-      | pid-4    |
-      | pid-5    |
+      | material  |
+      | 123-kat:2 |
+      | 123-kat:4 |
+      | 123-kat:5 |
     Then the list should contain:
-      | material |
-      | pid-4    |
-      | pid-2    |
+      | material  |
+      | 123-kat:4 |
+      | 123-kat:2 |

--- a/tests/features/get_list.feature
+++ b/tests/features/get_list.feature
@@ -37,6 +37,16 @@ Feature: Fetching list
     When checking if "123-kat:2" is on the list
     Then the system should return success
 
+  Scenario: Checking a material requires an valid pid
+    Given a known user
+    And they have the following items on the list:
+      | material  |
+      | 123-kat:1 |
+      | 123-kat:2 |
+      | 123-kat:3 |
+    When checking if "banana" is on the list
+    Then the system should return validation error
+
   Scenario: A user can check that a material is not on the list
     Given a known user
     And they have the following items on the list:
@@ -64,3 +74,26 @@ Feature: Fetching list
       | material  |
       | 123-kat:4 |
       | 123-kat:2 |
+
+  Scenario: Checking a list of materials requires valid pids
+    Given a known user
+    And they have the following items on the list:
+        | material  |
+        | 123-kat:1 |
+        | 123-kat:2 |
+        | 123-kat:3 |
+    When checking if the list contains:
+      | material  |
+      | 123-kat:2 |
+      | banana    |
+    Then the system should return validation error
+
+  Scenario: A user can check that a material is on the list, with another agency
+    Given a known user
+    And they have the following items on the list:
+      | material      |
+      | 123-katalog:1 |
+      | 123-katalog:2 |
+      | 123-katalog:3 |
+    When checking if "321-basis:2" is on the list
+    Then the system should return success

--- a/tests/features/order.feature
+++ b/tests/features/order.feature
@@ -3,13 +3,13 @@ Feature: List order
 
   Scenario: Order by the last added first.
     Given a known user that has no items on list
-    When "pid-1" is added to the list
-    And "pid-2" is added to the list
-    And "pid-3" is added to the list
+    When "123-kat:1" is added to the list
+    And "123-kat:2" is added to the list
+    And "123-kat:3" is added to the list
     When fetching the list
     Then the system should return success
     And the list should contain:
-      | material |
-      | pid-3    |
-      | pid-2    |
-      | pid-1    |
+      | material  |
+      | 123-kat:3 |
+      | 123-kat:2 |
+      | 123-kat:1 |


### PR DESCRIPTION
We need to handle that material records might be locally overridden on
a particular library, which gives it another pid. So for materials
that start with "<agency id>-katalog" and "<agency id>-basis", we
treat it as the same material.
