### PR TITLE
Replace deprecated Google Cloud Action by GitHub with official action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -113,19 +113,15 @@ jobs:
     - name: Build release Docker image
       run: docker build -t "eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
           -f infrastructure/docker/release/Dockerfile .
-    - name: Set Credential Helper for Docker
-      uses: actions/gcloud/cli@master
-      with:
-        args: auth configure-docker --quiet
     - name: Setup Google Cloud
-      uses: actions/gcloud/auth@master
-      env:
-        GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
-    - name: Push image to GCR
-      uses: actions/gcloud/cli@master
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
-        entrypoint: sh
-        args: -c "docker push eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}"
+        version: '275.0.0'
+        service_account_key: ${{ secrets.GCLOUD_AUTH }}
+    - name: Set Credential Helper for Docker
+      run: gcloud auth configure-docker --quiet
+    - name: Push image to GCR
+      run: docker push eu.gcr.io/reload-material-list-3/material-list-release:${{ github.sha }}
     - name: Deploy to Test
       uses: ./.github/actions/deployer
       env:


### PR DESCRIPTION
[actions/gcloud are deprecated] and [now no longer available](https://github.com/reload/material-list/runs/411599574?check_suite_focus=true). 
Consequently we have to move to the official actions released by
Google.

Setup is now handled by [a single action](https://github.com/GoogleCloudPlatform/github-actions/blob/master/setup-gcloud/README.md) which requires both service
account email and key, so we use that to setup the connection. *Then*
we can use the now available version of `gcloud` to configure Docker
and execute further actions.