### PR TITLE
Use stderr for Lumen error handling on Kubernetes

### DIFF
--- a/infrastructure/k8s/overlays/prod/.env.template
+++ b/infrastructure/k8s/overlays/prod/.env.template
@@ -22,7 +22,7 @@ ADGANGSPLATFORMEN_CLIENT_ID=${APP_CLIENT_ID}
 ADGANGSPLATFORMEN_CLIENT_SECRET=${APP_CLIENT_SECRET}
 
 # Logging configuration. See the Lumen documentation for more info.
-LOG_CHANNEL=stack
+LOG_CHANNEL=stderr
 
 # Database connection information. Mysql example:
 DB_CONNECTION=mysql

--- a/infrastructure/k8s/overlays/test/.env.template
+++ b/infrastructure/k8s/overlays/test/.env.template
@@ -22,7 +22,7 @@ ADGANGSPLATFORMEN_CLIENT_ID=${APP_CLIENT_ID}
 ADGANGSPLATFORMEN_CLIENT_SECRET=${APP_CLIENT_SECRET}
 
 # Logging configuration. See the Lumen documentation for more info.
-LOG_CHANNEL=stack
+LOG_CHANNEL=stderr
 
 # Database connection information. Mysql example:
 DB_CONNECTION=mysql


### PR DESCRIPTION
The current configuration uses default behavior which is to log to a 
file. This is not very useful for our GKE-based environments where we
want to send our logs to Stackdriver.

Stackdriver picks up data from stdout and stderr.

Consequently we switch to the stderr log channel which is provided by
default in Lumen.
https://github.com/laravel/lumen-framework/blob/6.x/config/logging.php#L74