### PR TITLE
Handle duplicates on migration

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -78,7 +78,7 @@ jobs:
         composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
     - name: Install Dredd
       run: |
-        npm install dredd --no-optional
+        npm install dredd@12 --no-optional
     - name: Specification tests
       env:
         ADGANGSPLATFORMEN_DRIVER: testing

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ API specification tests are done by generating requests as documented
 by the specification and testing if the application reacts as
 documented. [Dredd](https://dredd.org/en/latest/) is used for this.
 
-To install Dredd, run: `npm install --global dredd`.
+To install Dredd, run: `npm install --global dredd@12`.
 
 Running Dredd is as simple as `dredd`. Dredd is configured to run
 `php -S 0.0.0.0:8080 -t public` to start the server, which simply runs the

--- a/app/Http/Controllers/MigrateController.php
+++ b/app/Http/Controllers/MigrateController.php
@@ -12,9 +12,34 @@ class MigrateController extends Controller
     public function migrate(Request $request, string $openlistId)
     {
         // The "legacy-" prefix protects against high-jacking from another GUID.
-        $materials = DB::table('materials')
-            ->where(['guid' => 'legacy-' . $openlistId])
-            ->update(['guid' => $request->user()->getId()]);
+        // We have to use a raw query here as Illuminate/DB does not support
+        // UPDATE IGNORE. We need this to avoid duplicate entry errors if the
+        // user has added an item on a list manually which also exists in
+        // the materials to be migrated.
+        $query = "UPDATE IGNORE materials SET guid=:guid WHERE guid=:legacy";
+
+        // SQLite which we use for testing requires has a bit different syntax
+        // for updates which should ignore duplicate key conflicts.
+        $database = config('database.default');
+        if ($database) {
+            $driver = config("database.connections.${database}.driver");
+        } else {
+            // Config does not seem to work for Dredd tests. Fall back to
+            // environment variable checking.
+            $driver = env('DB_CONNECTION');
+        }
+
+        if ($driver == "sqlite") {
+            $query = "UPDATE OR IGNORE materials SET guid=:guid WHERE guid=:legacy";
+        }
+
+        DB::statement(
+            $query,
+            [
+                ':legacy' => 'legacy-' . $openlistId,
+                ':guid' => $request->user()->getId()
+            ]
+        );
 
         // Always return success.
         return new Response('', 204);

--- a/tests/features/migrate.feature
+++ b/tests/features/migrate.feature
@@ -14,3 +14,15 @@ Feature: List migration
       | third    |
       | second   |
       | first    |
+
+  Scenario: Migration can handle duplicates
+    Given a known user
+    And they have the following items on the list:
+      | material |
+      | first    |
+    And a migrated list for legacy user id "the-ouid":
+      | material |
+      | first    |
+      | second   |
+    When the user runs migrate for legacy user id "the-ouid"
+    Then the system should return success


### PR DESCRIPTION
This can happen if the user begins adding data to her list before a
migration finishes. Either because it is not initiated or because it
is failing.